### PR TITLE
feat: ghapp role — runtime-minted repo-scoped GitHub App tokens

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
           - packages
           - docker
           - podman
+          - ghapp
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Do **not** remove the `verify` step from `molecule.yml` test sequences.
 
 ### CI scenarios
 
-CI runs `host_prep` and `packages` scenarios. `default` and `podman` are available locally but excluded from CI.
+CI runs the `host_prep`, `packages`, `docker`, `podman`, and `ghapp` scenarios. `default` is available locally but excluded from CI.
 
 ## Coding standards
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COLLECTION_NAMESPACE := david_igou
 COLLECTION_NAME := devhost
 COLLECTION := $(COLLECTION_NAMESPACE).$(COLLECTION_NAME)
 
-MOLECULE_SCENARIOS := default host_prep packages podman docker container_runtimes
+MOLECULE_SCENARIOS := default host_prep packages podman docker container_runtimes ghapp
 PROVISIONER ?= podman
 
 .PHONY: help lint molecule molecule-kubevirt test collection-build collection-install galaxy-import clean

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ansible collection that provisions a bare Linux host for VS Code/Cursor remote-s
 | [`packages`](roles/packages/) | System packages, third-party repos, versioned CLI binaries, pip packages, devcontainer CLI |
 | [`podman`](roles/podman/) | Podman installation, kernel tuning, rootless config, socket activation, storage config |
 | [`docker`](roles/docker/) | Docker CE lifecycle: repo setup, CLI, compose plugin, daemon config, rootless mode |
+| [`ghapp`](roles/ghapp/) | Runtime-minted repo-scoped GitHub App tokens: CLI + git credential helper, optional unix-socket token broker for containerized agents |
 
 ## Installation
 

--- a/changelogs/fragments/ghapp-role.yml
+++ b/changelogs/fragments/ghapp-role.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - >-
+    New ``ghapp`` role — installs the ghapp CLI / git credential helper
+    (runtime-minted, single-repo, permission-scoped GitHub App tokens) into a
+    dedicated virtualenv, and optionally configures either local-mint client
+    mode (per-user config + gitconfig credential helper) or a hardened
+    systemd token-broker service that owns the App private key as a dedicated
+    system user and serves policy-clamped tokens over a unix socket for
+    containerized agents.

--- a/extensions/molecule/ghapp/converge.yml
+++ b/extensions/molecule/ghapp/converge.yml
@@ -1,0 +1,43 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  become: false
+
+  vars:
+    __molecule_fake_pem: |
+      -----BEGIN RSA PRIVATE KEY-----
+      bW9sZWN1bGUtZmFrZS1rZXktbm90LWEtcmVhbC1rZXk=
+      -----END RSA PRIVATE KEY-----
+    ghapp_client_enabled: true
+    ghapp_client_user: root
+    ghapp_client_id: "Iv23moleculeclient"
+    ghapp_client_app_slug: molecule-test
+    ghapp_client_installations:
+      exampleorg: "111"
+      exampleuser: "222"
+    ghapp_client_private_key_content: "{{ __molecule_fake_pem }}"
+    ghapp_broker_enabled: true
+    ghapp_broker_manage_service: false
+    ghapp_broker_client_id: "Iv23moleculebroker"
+    ghapp_broker_app_slug: molecule-broker
+    ghapp_broker_installations:
+      exampleorg: "111"
+    ghapp_broker_private_key_content: "{{ __molecule_fake_pem }}"
+    ghapp_broker_policy:
+      allowed_repos:
+        - exampleorg/allowed-repo
+      max_permissions:
+        contents: write
+      default_permissions:
+        contents: read
+
+  roles:
+    - role: david_igou.devhost.ghapp
+
+  pre_tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      become: true
+      when: ansible_facts.os_family == "Debian"

--- a/extensions/molecule/ghapp/molecule.yml
+++ b/extensions/molecule/ghapp/molecule.yml
@@ -1,0 +1,63 @@
+---
+# ghapp scenario: installs the ghapp role in both modes (client local-mint
+# config + broker) and smoke-tests the broker over its unix socket. The
+# containers have no systemd, so the broker service is started manually in
+# verify (ghapp_broker_manage_service: false).
+dependency:
+  name: galaxy
+  options:
+    requirements-file: extensions/molecule/provisioners/${PROVISIONER:-podman}/requirements.yml
+    force: true
+driver:
+  name: default
+  options:
+    managed: true
+    ansible_connection_options:
+      connection: local
+platforms:
+  - name: ubuntu-24
+    podman:
+      image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+      command: sleep 1d
+    kubevirt:
+      image: quay.io/containerdisks/ubuntu:24.04
+      namespace: ${MOLECULE_NAMESPACE:-molecule}
+      ssh_service:
+        type: NodePort
+      ansible_user: cloud-user
+      memory: 4Gi
+  - name: centos-stream-10
+    podman:
+      image: quay.io/centos/centos:stream10
+      command: sleep 1d
+    kubevirt:
+      image: quay.io/containerdisks/centos-stream:10
+      namespace: ${MOLECULE_NAMESPACE:-molecule}
+      ssh_service:
+        type: NodePort
+      ansible_user: cloud-user
+      memory: 4Gi
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    create: ../provisioners/${PROVISIONER:-podman}/create.yml
+    destroy: ../provisioners/${PROVISIONER:-podman}/destroy.yml
+    prepare: ../provisioners/${PROVISIONER:-podman}/prepare.yml
+    verify: verify.yml
+  inventory:
+    links:
+      group_vars: ../provisioners/${PROVISIONER:-podman}/group_vars/
+verifier:
+  name: ansible
+scenario:
+  name: ghapp
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/extensions/molecule/ghapp/verify.yml
+++ b/extensions/molecule/ghapp/verify.yml
@@ -1,0 +1,195 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  become: false
+
+  vars:
+    __ghapp_socket: /run/ghbroker/ghbroker.sock
+
+  tasks:
+    - name: Check ghapp console scripts on the PATH
+      ansible.builtin.command:
+        cmd: "{{ item }} --help"
+      changed_when: false
+      loop:
+        - /usr/local/bin/ghapp
+        - /usr/local/bin/gh-app
+        - /usr/local/bin/git-app
+
+    - name: Check the credential helper handles store as a no-op
+      ansible.builtin.command:
+        cmd: /usr/local/bin/git-credential-ghapp store
+      changed_when: false
+
+    - name: Read the rendered client config
+      ansible.builtin.slurp:
+        src: /root/.config/ghapp/config.yaml
+      register: __client_config
+      become: true
+
+    - name: Assert the client config content
+      ansible.builtin.assert:
+        that:
+          - __client_yaml.github_app.client_id == "Iv23moleculeclient"
+          - __client_yaml.github_app.installations.exampleorg == "111"
+          - __client_yaml.github_app.installations.exampleuser == "222"
+          - __client_yaml.github_app.private_key_path == "/root/.config/ghapp/key.pem"
+        fail_msg: "client config.yaml does not match the converge vars"
+      vars:
+        __client_yaml: "{{ __client_config.content | b64decode | from_yaml }}"
+
+    - name: Stat the client private key
+      ansible.builtin.stat:
+        path: /root/.config/ghapp/key.pem
+      register: __client_key
+      become: true
+
+    - name: Assert the client key is locked down
+      ansible.builtin.assert:
+        that:
+          - __client_key.stat.exists
+          - __client_key.stat.mode == "0600"
+        fail_msg: "client key.pem missing or not 0600"
+
+    - name: Check the git credential helper configuration  # noqa: command-instead-of-module -- read-only verify of what git itself resolves
+      ansible.builtin.command:
+        cmd: git config --global --get "credential.https://github.com.{{ item.key }}"
+      register: __git_config
+      changed_when: false
+      failed_when: __git_config.stdout != item.value
+      loop:
+        - key: helper
+          value: ghapp
+        - key: useHttpPath
+          value: "true"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Stat the broker private key
+      ansible.builtin.stat:
+        path: /etc/ghbroker/key.pem
+      register: __broker_key
+      become: true
+
+    - name: Assert the broker key is owned by ghbroker and 0600
+      ansible.builtin.assert:
+        that:
+          - __broker_key.stat.exists
+          - __broker_key.stat.mode == "0600"
+          - __broker_key.stat.pw_name == "ghbroker"
+        fail_msg: "broker key.pem missing, wrong owner, or not 0600"
+
+    - name: Assert the broker key is unreadable to a non-ghbroker user
+      ansible.builtin.command:
+        cmd: runuser -u nobody -- cat /etc/ghbroker/key.pem
+      register: __key_probe
+      changed_when: false
+      failed_when: __key_probe.rc == 0
+      become: true
+
+    - name: Create the broker runtime directory (no systemd in molecule)
+      ansible.builtin.file:
+        path: /run/ghbroker
+        state: directory
+        owner: ghbroker
+        group: ghbroker
+        mode: "0750"
+      become: true
+
+    - name: Start the broker manually in the background
+      ansible.builtin.shell:
+        cmd: >-
+          nohup runuser -u ghbroker --
+          env GHAPP_CONFIG=/etc/ghbroker/config.yaml
+          /opt/ghapp/bin/ghapp serve
+          --socket {{ __ghapp_socket }}
+          --policy /etc/ghbroker/policy.yaml
+          > /tmp/ghapp-broker.log 2>&1 &
+          echo $! > /tmp/ghapp-broker.pid
+      changed_when: true
+      become: true
+      # noqa command-instead-of-shell -- backgrounding a daemon needs the shell
+
+    - name: Wait for the broker socket
+      ansible.builtin.wait_for:
+        path: "{{ __ghapp_socket }}"
+        timeout: 15
+      become: true
+
+    - name: Probe the broker health endpoint
+      ansible.builtin.uri:
+        url: http://localhost/healthz
+        unix_socket: "{{ __ghapp_socket }}"
+        return_content: true
+      register: __healthz
+      failed_when: __healthz.json.ok is not true
+      become: true
+
+    - name: Read the broker status endpoint
+      ansible.builtin.uri:
+        url: http://localhost/status
+        unix_socket: "{{ __ghapp_socket }}"
+        return_content: true
+      register: __status
+      become: true
+
+    - name: Assert the broker status reflects config and policy
+      ansible.builtin.assert:
+        that:
+          - __status.json.app_slug == "molecule-broker"
+          - __status.json.policy.allowed_repos == ["exampleorg/allowed-repo"]
+          - __status.json.policy.max_permissions.contents == "write"
+        fail_msg: "broker /status does not match the converged config/policy"
+
+    - name: Request a token for a repo outside the policy
+      ansible.builtin.uri:
+        url: http://localhost/token
+        unix_socket: "{{ __ghapp_socket }}"
+        method: POST
+        body_format: json
+        body:
+          repo: exampleorg/forbidden
+          permissions:
+            contents: read
+        status_code: 403
+      become: true
+
+    - name: Request a permission above the policy ceiling
+      ansible.builtin.uri:
+        url: http://localhost/token
+        unix_socket: "{{ __ghapp_socket }}"
+        method: POST
+        body_format: json
+        body:
+          repo: exampleorg/allowed-repo
+          permissions:
+            secrets: write
+        status_code: 403
+      become: true
+
+    - name: Check the denials were audited
+      ansible.builtin.command:
+        cmd: >-
+          grep -c '"decision": "denied"' /tmp/ghapp-broker.log
+      register: __audit
+      changed_when: false
+      failed_when: __audit.stdout | int < 2
+      become: true
+
+    - name: Stop the manually started broker
+      ansible.builtin.shell:
+        cmd: kill "$(cat /tmp/ghapp-broker.pid)"
+      register: __broker_kill
+      changed_when: __broker_kill.rc == 0
+      failed_when: false
+      become: true
+      # noqa command-instead-of-shell -- command substitution for the pidfile
+
+    - name: Summarize verification
+      ansible.builtin.debug:
+        msg: >-
+          Verified: console scripts callable, client config + 0600 key +
+          git credential helper, broker key ownership/permissions, broker
+          /healthz + /status over the unix socket, out-of-policy repo and
+          permission both denied with 403, denials present in the audit log.

--- a/roles/ghapp/README.md
+++ b/roles/ghapp/README.md
@@ -1,0 +1,61 @@
+# ghapp
+
+Runtime-minted, minimally scoped GitHub tokens from a GitHub App. Installs the
+[ghapp CLI / credential helper](https://github.com/david-igou/hermes_github_app_plugin)
+and configures one (or both) of its two modes:
+
+- **Client / local-mint mode** — the target user's environment mints
+  single-repo, permission-scoped installation tokens in-process. The git
+  credential helper makes plain `git push` on HTTPS GitHub remotes work with a
+  fresh ~1 h token per operation; nothing is stored. The App private key comes
+  from a command resolved at mint time (e.g. `op read ...`), an existing PEM
+  path, or inline content the role writes to a `0600` file.
+- **Broker mode** — a hardened systemd service (`ghapp serve`) runs as a
+  dedicated system user that owns the App key and serves policy-clamped tokens
+  over a unix socket. Agent containers get the socket bind-mounted and set
+  `GHAPP_BROKER_SOCKET`; they hold no key material, and requests outside the
+  repository allowlist / permission ceiling are denied and audited to journald.
+
+## Example: devcontainer host (local mint via 1Password)
+
+```yaml
+- role: david_igou.devhost.ghapp
+  vars:
+    ghapp_client_enabled: true
+    ghapp_client_user: igou
+    ghapp_client_id: "Iv23exampleclientid"
+    ghapp_client_app_slug: igou-dev
+    ghapp_client_installations:
+      david-igou: "143866260"
+      igou-io: "143866153"
+    ghapp_client_private_key_cmd: op read op://claude/igou-dev-github-app/private_key
+```
+
+## Example: agent VM broker (key delivered from AAP, containers get the socket)
+
+```yaml
+- role: david_igou.devhost.ghapp
+  vars:
+    ghapp_broker_enabled: true
+    ghapp_broker_socket_group: hermes
+    ghapp_broker_client_id: "Iv23exampleclientid"
+    ghapp_broker_app_slug: igou-hermes
+    ghapp_broker_installations:
+      igou-io: "143866709"
+    ghapp_broker_private_key_content: "{{ hermes_github_app_private_key }}"  # no_log source
+    ghapp_broker_policy:
+      allowed_repos:
+        - igou-io/igou-ansible
+        - igou-io/igou-inventory
+      max_permissions:
+        contents: write
+        pull_requests: write
+        issues: write
+      default_permissions:
+        contents: read
+```
+
+Then mount `/run/ghbroker/ghbroker.sock` into the agent containers and set
+`GHAPP_BROKER_SOCKET=/run/ghbroker/ghbroker.sock` in their environment.
+
+See `meta/argument_specs.yml` for all variables.

--- a/roles/ghapp/defaults/main.yml
+++ b/roles/ghapp/defaults/main.yml
@@ -1,0 +1,59 @@
+---
+# Package installation (venv keeps us independent of PEP 668 / distro pip policy)
+ghapp_install: true
+ghapp_venv_path: /opt/ghapp
+ghapp_bin_dir: /usr/local/bin
+ghapp_package_git_url: https://github.com/david-igou/hermes_github_app_plugin
+ghapp_package_git_ref: main
+ghapp_package_spec: "hermes-github-app-plugin @ git+{{ ghapp_package_git_url }}@{{ ghapp_package_git_ref }}"
+ghapp_console_scripts:
+  - ghapp
+  - gh-app
+  - git-app
+  - git-credential-ghapp
+
+# Client / local-mint mode: renders the per-user config and git credential
+# helper so plain `git push` on HTTPS GitHub remotes mints repo-scoped tokens.
+ghapp_client_enabled: false
+ghapp_client_user: "{{ ansible_user_id }}"
+ghapp_client_id: ""
+ghapp_client_app_slug: ""
+# owner -> installation id, e.g. {david-igou: "143866260", igou-io: "143866153"}
+ghapp_client_installations: {}
+# Exactly one key source: a command resolved at mint time (preferred, e.g. an
+# `op read`), an existing PEM path, or inline content the role writes to disk.
+ghapp_client_private_key_cmd: ""
+ghapp_client_private_key_path: ""
+ghapp_client_private_key_content: ""
+ghapp_client_default_permissions: {}
+ghapp_client_configure_git_credential_helper: true
+# Export GHAPP_CONFIG for login shells so the CLI finds the per-user config.
+ghapp_client_profile_env: true
+
+# Broker mode: a dedicated system user owns the App key and serves
+# policy-clamped tokens over a unix socket (for containerized agents).
+ghapp_broker_enabled: false
+ghapp_broker_user: ghbroker
+ghapp_broker_group: ghbroker
+# Group granted connect access to the socket (e.g. the agent service user).
+ghapp_broker_socket_group: "{{ ghapp_broker_group }}"
+ghapp_broker_runtime_dir: ghbroker
+ghapp_broker_socket_path: "/run/{{ ghapp_broker_runtime_dir }}/ghbroker.sock"
+ghapp_broker_socket_mode: "0660"
+ghapp_broker_config_dir: /etc/ghbroker
+ghapp_broker_client_id: ""
+ghapp_broker_app_slug: ""
+ghapp_broker_installations: {}
+ghapp_broker_private_key_content: ""
+# policy.yaml content: allowed_repos (globs), max_permissions, default_permissions
+ghapp_broker_policy:
+  allowed_repos: []
+  max_permissions:
+    contents: write
+    pull_requests: write
+    issues: write
+  default_permissions:
+    contents: read
+ghapp_broker_service_name: ghapp-broker
+# Disable to skip systemd unit start (e.g. molecule containers without systemd).
+ghapp_broker_manage_service: true

--- a/roles/ghapp/handlers/main.yml
+++ b/roles/ghapp/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Restart the ghapp broker
+  ansible.builtin.systemd:
+    name: "{{ ghapp_broker_service_name }}.service"
+    state: restarted
+    daemon_reload: true
+  become: true
+  when: ghapp_broker_manage_service | bool

--- a/roles/ghapp/meta/argument_specs.yml
+++ b/roles/ghapp/meta/argument_specs.yml
@@ -1,0 +1,141 @@
+---
+argument_specs:
+  main:
+    short_description: Install ghapp and configure local-mint or broker GitHub App token minting
+    description:
+      - Installs the ghapp package (hermes-github-app-plugin) into a dedicated
+        virtualenv and symlinks its console scripts onto the system PATH.
+      - Client mode renders a per-user config (GitHub App client ID,
+        owner-to-installation map, private key source) and wires the git
+        credential helper so HTTPS GitHub operations mint fresh single-repo
+        tokens at runtime.
+      - Broker mode deploys a hardened systemd service running
+        C(ghapp serve) as a dedicated system user that owns the App private
+        key and serves policy-clamped tokens over a unix socket, for
+        containerized agents that must never see key material.
+    options:
+      ghapp_install:
+        type: bool
+        default: true
+        description: Install the package, virtualenv, and PATH symlinks.
+      ghapp_venv_path:
+        type: str
+        default: /opt/ghapp
+        description: Virtualenv directory for the package.
+      ghapp_bin_dir:
+        type: str
+        default: /usr/local/bin
+        description: Directory receiving console-script symlinks.
+      ghapp_package_git_url:
+        type: str
+        default: https://github.com/david-igou/hermes_github_app_plugin
+        description: Git URL the package installs from.
+      ghapp_package_git_ref:
+        type: str
+        default: main
+        description: Git ref (branch, tag, or SHA) of the package to install.
+      ghapp_package_spec:
+        type: str
+        description: Full pip requirement spec; overrides the URL/ref pair.
+      ghapp_console_scripts:
+        type: list
+        elements: str
+        description: Console scripts to symlink into ghapp_bin_dir.
+      ghapp_client_enabled:
+        type: bool
+        default: false
+        description: Render local-mint client configuration.
+      ghapp_client_user:
+        type: str
+        description: User receiving the client config and gitconfig helper.
+      ghapp_client_id:
+        type: str
+        description: GitHub App client ID (client mode).
+      ghapp_client_app_slug:
+        type: str
+        description: GitHub App slug, e.g. igou-dev.
+      ghapp_client_installations:
+        type: dict
+        description: Owner to installation-id map, one entry per account.
+      ghapp_client_private_key_cmd:
+        type: str
+        description: >-
+          Command printing the App PEM at mint time (e.g. an op read).
+          Exactly one key source must be set.
+      ghapp_client_private_key_path:
+        type: str
+        description: Path to an existing App PEM on the host.
+      ghapp_client_private_key_content:
+        type: str
+        description: Inline PEM the role writes to a 0600 file for the user.
+      ghapp_client_default_permissions:
+        type: dict
+        description: Default permission set for unspecified mints.
+      ghapp_client_configure_git_credential_helper:
+        type: bool
+        default: true
+        description: Set credential.https://github.com helper=ghapp + useHttpPath.
+      ghapp_client_profile_env:
+        type: bool
+        default: true
+        description: Export GHAPP_CONFIG for login shells via /etc/profile.d.
+      ghapp_broker_enabled:
+        type: bool
+        default: false
+        description: Deploy the unix-socket token broker service.
+      ghapp_broker_user:
+        type: str
+        default: ghbroker
+        description: Dedicated system user owning the App private key.
+      ghapp_broker_group:
+        type: str
+        default: ghbroker
+        description: Primary group of the broker user.
+      ghapp_broker_socket_group:
+        type: str
+        description: >-
+          Group granted connect access to the socket (the agent service
+          user's group). Defaults to the broker group.
+      ghapp_broker_runtime_dir:
+        type: str
+        default: ghbroker
+        description: systemd RuntimeDirectory name under /run.
+      ghapp_broker_socket_path:
+        type: str
+        description: Unix socket path the broker listens on.
+      ghapp_broker_socket_mode:
+        type: str
+        default: "0660"
+        description: Octal socket file mode.
+      ghapp_broker_config_dir:
+        type: str
+        default: /etc/ghbroker
+        description: Directory for the broker config, policy, and key.
+      ghapp_broker_client_id:
+        type: str
+        description: GitHub App client ID (broker mode).
+      ghapp_broker_app_slug:
+        type: str
+        description: GitHub App slug (broker mode).
+      ghapp_broker_installations:
+        type: dict
+        description: Owner to installation-id map (broker mode).
+      ghapp_broker_private_key_content:
+        type: str
+        description: App PEM content, written 0600 for the broker user only.
+      ghapp_broker_policy:
+        type: dict
+        description: >-
+          Minting policy rendered to policy.yaml. Keys: allowed_repos
+          (OWNER/REPO globs), max_permissions, default_permissions.
+          Out-of-policy requests are denied, never clamped.
+      ghapp_broker_service_name:
+        type: str
+        default: ghapp-broker
+        description: systemd service name (also the journald identifier).
+      ghapp_broker_manage_service:
+        type: bool
+        default: true
+        description: >-
+          Enable and start the systemd unit. Disable in environments without
+          systemd (e.g. molecule containers).

--- a/roles/ghapp/meta/main.yml
+++ b/roles/ghapp/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  role_name: ghapp
+  author: David Igou
+  description: >-
+    Runtime-minted, repo-scoped GitHub App tokens: installs the ghapp
+    CLI/credential helper and optionally deploys the unix-socket token broker
+    for containerized agent execution.
+  license: Apache-2.0
+  min_ansible_version: "2.16"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+    - name: EL
+      versions:
+        - "9"
+        - "10"
+
+dependencies: []

--- a/roles/ghapp/tasks/broker.yml
+++ b/roles/ghapp/tasks/broker.yml
@@ -1,0 +1,103 @@
+---
+- name: Assert the broker configuration is complete
+  ansible.builtin.assert:
+    that:
+      - ghapp_broker_client_id | length > 0
+      - ghapp_broker_installations | length > 0
+      - ghapp_broker_private_key_content | length > 0
+      - ghapp_broker_policy.allowed_repos | length > 0
+    fail_msg: >-
+      ghapp broker mode needs ghapp_broker_client_id, ghapp_broker_installations,
+      ghapp_broker_private_key_content, and a non-empty
+      ghapp_broker_policy.allowed_repos list.
+
+- name: Create the broker group
+  ansible.builtin.group:
+    name: "{{ ghapp_broker_group }}"
+    system: true
+    state: present
+  become: true
+
+- name: Create the socket-access group
+  ansible.builtin.group:
+    name: "{{ ghapp_broker_socket_group }}"
+    system: false
+    state: present
+  become: true
+  when: ghapp_broker_socket_group != ghapp_broker_group
+
+- name: Create the broker system user
+  ansible.builtin.user:
+    name: "{{ ghapp_broker_user }}"
+    group: "{{ ghapp_broker_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+    state: present
+  become: true
+
+- name: Create the broker config directory
+  ansible.builtin.file:
+    path: "{{ ghapp_broker_config_dir }}"
+    state: directory
+    owner: root
+    group: "{{ ghapp_broker_group }}"
+    mode: "0750"
+  become: true
+
+- name: Write the broker private key
+  ansible.builtin.copy:
+    content: "{{ ghapp_broker_private_key_content }}"
+    dest: "{{ ghapp_broker_config_dir }}/key.pem"
+    owner: "{{ ghapp_broker_user }}"
+    group: "{{ ghapp_broker_group }}"
+    mode: "0600"
+  become: true
+  no_log: true
+  notify: Restart the ghapp broker
+
+- name: Render the broker ghapp config
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ ghapp_broker_config_dir }}/config.yaml"
+    owner: root
+    group: "{{ ghapp_broker_group }}"
+    mode: "0640"
+  become: true
+  vars:
+    __ghapp_config_client_id: "{{ ghapp_broker_client_id }}"
+    __ghapp_config_app_slug: "{{ ghapp_broker_app_slug }}"
+    __ghapp_config_installations: "{{ ghapp_broker_installations }}"
+    __ghapp_config_private_key_cmd: ""
+    __ghapp_config_private_key_path: "{{ ghapp_broker_config_dir }}/key.pem"
+    __ghapp_config_default_permissions: {}
+  notify: Restart the ghapp broker
+
+- name: Render the broker policy (deny-not-clamp; root-owned, agent-immutable)
+  ansible.builtin.template:
+    src: policy.yaml.j2
+    dest: "{{ ghapp_broker_config_dir }}/policy.yaml"
+    owner: root
+    group: "{{ ghapp_broker_group }}"
+    mode: "0640"
+  become: true
+  notify: Restart the ghapp broker
+
+- name: Render the broker systemd unit
+  ansible.builtin.template:
+    src: ghapp-broker.service.j2
+    dest: "/etc/systemd/system/{{ ghapp_broker_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Restart the ghapp broker
+
+- name: Enable and start the broker service
+  ansible.builtin.systemd:
+    name: "{{ ghapp_broker_service_name }}.service"
+    enabled: true
+    state: started
+    daemon_reload: true
+  become: true
+  when: ghapp_broker_manage_service | bool

--- a/roles/ghapp/tasks/client.yml
+++ b/roles/ghapp/tasks/client.yml
@@ -1,0 +1,99 @@
+---
+- name: Assert the client configuration is complete
+  ansible.builtin.assert:
+    that:
+      - ghapp_client_id | length > 0
+      - ghapp_client_installations | length > 0
+      - >-
+        [ghapp_client_private_key_cmd, ghapp_client_private_key_path,
+         ghapp_client_private_key_content]
+        | select('ne', '') | list | length == 1
+    fail_msg: >-
+      ghapp client mode needs ghapp_client_id, ghapp_client_installations, and
+      exactly one of ghapp_client_private_key_cmd / _path / _content.
+
+- name: Look up the client user's home directory
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ ghapp_client_user }}"
+  become: true
+
+- name: Set client path facts
+  ansible.builtin.set_fact:
+    __ghapp_client_home: "{{ ansible_facts.getent_passwd[ghapp_client_user][4] }}"
+
+- name: Set client config path facts
+  ansible.builtin.set_fact:
+    __ghapp_client_config_dir: "{{ __ghapp_client_home }}/.config/ghapp"
+    __ghapp_client_key_path: >-
+      {{ ghapp_client_private_key_path
+         if ghapp_client_private_key_path | length > 0
+         else __ghapp_client_home ~ '/.config/ghapp/key.pem' }}
+
+- name: Create the client config directory
+  ansible.builtin.file:
+    path: "{{ __ghapp_client_config_dir }}"
+    state: directory
+    owner: "{{ ghapp_client_user }}"
+    group: "{{ ghapp_client_user }}"
+    mode: "0700"
+  become: true
+
+- name: Write the client private key
+  ansible.builtin.copy:
+    content: "{{ ghapp_client_private_key_content }}"
+    dest: "{{ __ghapp_client_key_path }}"
+    owner: "{{ ghapp_client_user }}"
+    group: "{{ ghapp_client_user }}"
+    mode: "0600"
+  become: true
+  no_log: true
+  when: ghapp_client_private_key_content | length > 0
+
+- name: Render the client ghapp config
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ __ghapp_client_config_dir }}/config.yaml"
+    owner: "{{ ghapp_client_user }}"
+    group: "{{ ghapp_client_user }}"
+    mode: "0600"
+  become: true
+  vars:
+    __ghapp_config_client_id: "{{ ghapp_client_id }}"
+    __ghapp_config_app_slug: "{{ ghapp_client_app_slug }}"
+    __ghapp_config_installations: "{{ ghapp_client_installations }}"
+    __ghapp_config_private_key_cmd: "{{ ghapp_client_private_key_cmd }}"
+    __ghapp_config_private_key_path: >-
+      {{ '' if ghapp_client_private_key_cmd | length > 0 else __ghapp_client_key_path }}
+    __ghapp_config_default_permissions: "{{ ghapp_client_default_permissions }}"
+
+- name: Export GHAPP_CONFIG for login shells
+  ansible.builtin.copy:
+    content: |
+      # Managed by david_igou.devhost.ghapp
+      if [ -f "$HOME/.config/ghapp/config.yaml" ]; then
+        export GHAPP_CONFIG="$HOME/.config/ghapp/config.yaml"
+      fi
+    dest: /etc/profile.d/ghapp.sh
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  when: ghapp_client_profile_env | bool
+
+- name: Configure the git credential helper for github.com
+  community.general.git_config:
+    name: "credential.https://github.com.{{ item.key }}"
+    value: "{{ item.value }}"
+    scope: global
+    state: present
+  become: true
+  become_user: "{{ ghapp_client_user }}"
+  loop:
+    - key: helper
+      value: ghapp
+    - key: useHttpPath
+      value: "true"
+  loop_control:
+    label: "{{ item.key }}"
+  when: ghapp_client_configure_git_credential_helper | bool

--- a/roles/ghapp/tasks/install.yml
+++ b/roles/ghapp/tasks/install.yml
@@ -1,0 +1,35 @@
+---
+- name: Install venv and git prerequisites (Debian)
+  ansible.builtin.package:
+    name:
+      - python3-venv
+      - git
+    state: present
+  become: true
+  when: ansible_facts.os_family == "Debian"
+
+- name: Install git and pip-module prerequisites (RedHat)
+  ansible.builtin.package:
+    name:
+      - git
+      - python3-packaging
+      - python3-pip
+    state: present
+  become: true
+  when: ansible_facts.os_family == "RedHat"
+
+- name: Install ghapp into its virtualenv
+  ansible.builtin.pip:
+    name: "{{ ghapp_package_spec }}"
+    state: present
+    virtualenv: "{{ ghapp_venv_path }}"
+    virtualenv_command: "python3 -m venv"
+  become: true
+
+- name: Symlink ghapp console scripts into the system PATH
+  ansible.builtin.file:
+    src: "{{ ghapp_venv_path }}/bin/{{ item }}"
+    dest: "{{ ghapp_bin_dir }}/{{ item }}"
+    state: link
+  become: true
+  loop: "{{ ghapp_console_scripts }}"

--- a/roles/ghapp/tasks/main.yml
+++ b/roles/ghapp/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install the ghapp package
+  ansible.builtin.include_tasks: install.yml
+  when: ghapp_install | bool
+
+- name: Configure the local-mint client
+  ansible.builtin.include_tasks: client.yml
+  when: ghapp_client_enabled | bool
+
+- name: Deploy the token broker
+  ansible.builtin.include_tasks: broker.yml
+  when: ghapp_broker_enabled | bool

--- a/roles/ghapp/templates/config.yaml.j2
+++ b/roles/ghapp/templates/config.yaml.j2
@@ -1,0 +1,22 @@
+# {{ ansible_managed }}
+---
+github_app:
+  client_id: "{{ __ghapp_config_client_id }}"
+{% if __ghapp_config_app_slug | length > 0 %}
+  app_slug: "{{ __ghapp_config_app_slug }}"
+{% endif %}
+  installations:
+{% for owner, installation_id in __ghapp_config_installations.items() %}
+    {{ owner }}: "{{ installation_id }}"
+{% endfor %}
+{% if __ghapp_config_private_key_cmd | length > 0 %}
+  private_key_cmd: {{ __ghapp_config_private_key_cmd }}
+{% else %}
+  private_key_path: {{ __ghapp_config_private_key_path }}
+{% endif %}
+{% if __ghapp_config_default_permissions | length > 0 %}
+  default_permissions:
+{% for name, level in __ghapp_config_default_permissions.items() %}
+    {{ name }}: {{ level }}
+{% endfor %}
+{% endif %}

--- a/roles/ghapp/templates/ghapp-broker.service.j2
+++ b/roles/ghapp/templates/ghapp-broker.service.j2
@@ -1,0 +1,33 @@
+# {{ ansible_managed }}
+[Unit]
+Description=ghapp GitHub App token broker (policy-clamped repo-scoped tokens over a unix socket)
+Documentation=https://github.com/david-igou/hermes_github_app_plugin
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User={{ ghapp_broker_user }}
+# The unit group controls who may connect: the socket is created 0660
+# {{ ghapp_broker_user }}:{{ ghapp_broker_socket_group }} inside RuntimeDirectory.
+Group={{ ghapp_broker_socket_group }}
+Environment=GHAPP_CONFIG={{ ghapp_broker_config_dir }}/config.yaml
+ExecStart={{ ghapp_venv_path }}/bin/ghapp serve --socket {{ ghapp_broker_socket_path }} --policy {{ ghapp_broker_config_dir }}/policy.yaml --socket-mode {{ ghapp_broker_socket_mode }}
+RuntimeDirectory={{ ghapp_broker_runtime_dir }}
+RuntimeDirectoryMode=0750
+SyslogIdentifier={{ ghapp_broker_service_name }}
+Restart=on-failure
+RestartSec=2
+
+# Hardening: the only writable path is the runtime socket directory.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+CapabilityBoundingSet=
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/ghapp/templates/policy.yaml.j2
+++ b/roles/ghapp/templates/policy.yaml.j2
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+# Broker minting policy: requests outside this are DENIED (never clamped)
+# and every decision is audited to journald (SYSLOG_IDENTIFIER={{ ghapp_broker_service_name }}).
+---
+policy:
+  allowed_repos:
+{% for repo in ghapp_broker_policy.allowed_repos %}
+    - {{ repo }}
+{% endfor %}
+  max_permissions:
+{% for name, level in (ghapp_broker_policy.max_permissions | default({'contents': 'write'})).items() %}
+    {{ name }}: {{ level }}
+{% endfor %}
+  default_permissions:
+{% for name, level in (ghapp_broker_policy.default_permissions | default({'contents': 'read'})).items() %}
+    {{ name }}: {{ level }}
+{% endfor %}


### PR DESCRIPTION
## What

New `ghapp` role installing the [ghapp CLI / git credential helper](https://github.com/david-igou/hermes_github_app_plugin) (runtime-minted, single-repo, permission-scoped GitHub App installation tokens) into a dedicated virtualenv, with two gated modes:

- **client (local mint)** — per-user `~/.config/ghapp/config.yaml` (client ID, owner→installation map, key via `op read` cmd / path / delivered content), `GHAPP_CONFIG` profile.d export, and the github.com git credential helper (`useHttpPath`) so plain HTTPS `git push` mints a fresh single-repo token per operation. For the devenv/devcontainer hosts.
- **broker** — a dedicated `ghbroker` system user owns the App key (`/etc/ghbroker`, 0600); a hardened systemd unit runs `ghapp serve` on `/run/ghbroker/ghbroker.sock` with a root-owned deny-not-clamp policy (repo allowlist + permission ceiling) and JSON audit to journald. The unit `Group=` grants socket access to the agent service user, whose containers bind-mount the runtime dir and set `GHAPP_BROKER_SOCKET` — no key material ever enters agent-controlled processes. For the Hermes VM.

## Testing

New molecule scenario `ghapp` (added to the CI matrix), green locally on ubuntu-24 + centos-stream-10 including idempotence: converges both modes with a fake key, then verifies config/key ownership+modes, credential-helper wiring, key unreadable to other users, and a live broker smoke test over the unix socket (`/healthz`, `/status` policy match, 403 for an out-of-policy repo and an over-ceiling permission, denials present in the audit log). `ansible-lint` production profile passes.

## Context / follow-ups

Part of the GitHub App runtime-token rollout (design doc: `hermes_github_app_plugin/docs/design-minimal-runtime-tokens.md`). Merge order: this → release (so `igou-awx-ee` picks it up via igou-ansible requirements) → gated igou-ansible playbook changes (devenv bootstrap + hermes broker wiring, both default-off) → e2e on the devenv and hermes-test VMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `ghapp` role for managing GitHub App token workflows, including client and broker modes.
  * Included a new broker service with policy-based access controls and hardened runtime settings.
* **Documentation**
  * Expanded the README and role docs with setup examples and configuration details.
  * Updated release notes to reflect the new role.
* **Tests**
  * Added a new Molecule scenario and verification coverage for the `ghapp` setup.
  * Updated CI and local test scenario lists to include `ghapp`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->