### PR TITLE
fix(ghapp): broker unit needs SupplementaryGroups when socket group differs

### DIFF
--- a/changelogs/fragments/broker-supplementary-groups.yml
+++ b/changelogs/fragments/broker-supplementary-groups.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - >-
+    ghapp broker unit — add ``SupplementaryGroups={{ ghapp_broker_group }}``:
+    ``Group=`` (the socket-access group) replaces the primary gid, which cost
+    the broker its group-read on the config/policy files and crash-looped the
+    service whenever the socket group differed from the broker group (the
+    Hermes wiring). Found live in the kubevirt e2e scenario.

--- a/extensions/molecule/ghapp/converge.yml
+++ b/extensions/molecule/ghapp/converge.yml
@@ -19,6 +19,11 @@
     ghapp_client_private_key_content: "{{ __molecule_fake_pem }}"
     ghapp_broker_enabled: true
     ghapp_broker_manage_service: false
+    # Distinct socket-access group: the systemd unit runs with
+    # Group=<socket_group>, which replaces the primary gid — the broker must
+    # still read the ghbroker-group config/policy via SupplementaryGroups.
+    # Keeping this split in the scenario covers that path.
+    ghapp_broker_socket_group: ghapp-clients
     ghapp_broker_client_id: "Iv23moleculebroker"
     ghapp_broker_app_slug: molecule-broker
     ghapp_broker_installations:

--- a/extensions/molecule/ghapp/verify.yml
+++ b/extensions/molecule/ghapp/verify.yml
@@ -97,10 +97,14 @@
         mode: "0750"
       become: true
 
+    # Mirror the systemd unit's credentials exactly: uid=ghbroker,
+    # gid=<socket group>, supplementary=ghbroker (Group= replaces the primary
+    # gid, so config/policy reads depend on the supplementary group).
     - name: Start the broker manually in the background
       ansible.builtin.shell:
         cmd: >-
-          nohup runuser -u ghbroker --
+          nohup setpriv --reuid ghbroker --regid ghapp-clients --groups
+          "$(getent group ghbroker | cut -d: -f3)"
           env GHAPP_CONFIG=/etc/ghbroker/config.yaml
           /opt/ghapp/bin/ghapp serve
           --socket {{ __ghapp_socket }}

--- a/extensions/molecule/ghapp/verify.yml
+++ b/extensions/molecule/ghapp/verify.yml
@@ -103,8 +103,7 @@
     - name: Start the broker manually in the background
       ansible.builtin.shell:
         cmd: >-
-          nohup setpriv --reuid ghbroker --regid ghapp-clients --groups
-          "$(getent group ghbroker | cut -d: -f3)"
+          nohup setpriv --reuid ghbroker --regid ghapp-clients --groups ghbroker
           env GHAPP_CONFIG=/etc/ghbroker/config.yaml
           /opt/ghapp/bin/ghapp serve
           --socket {{ __ghapp_socket }}

--- a/roles/ghapp/templates/ghapp-broker.service.j2
+++ b/roles/ghapp/templates/ghapp-broker.service.j2
@@ -11,6 +11,11 @@ User={{ ghapp_broker_user }}
 # The unit group controls who may connect: the socket is created 0660
 # {{ ghapp_broker_user }}:{{ ghapp_broker_socket_group }} inside RuntimeDirectory.
 Group={{ ghapp_broker_socket_group }}
+# Group= replaces the primary gid, which would otherwise cost the process its
+# group-read on the {{ ghapp_broker_group }}-group config/policy under
+# {{ ghapp_broker_config_dir }} (observed: PermissionError on config.yaml and
+# a start-limit crash loop whenever socket_group != broker group).
+SupplementaryGroups={{ ghapp_broker_group }}
 Environment=GHAPP_CONFIG={{ ghapp_broker_config_dir }}/config.yaml
 ExecStart={{ ghapp_venv_path }}/bin/ghapp serve --socket {{ ghapp_broker_socket_path }} --policy {{ ghapp_broker_config_dir }}/policy.yaml --socket-mode {{ ghapp_broker_socket_mode }}
 RuntimeDirectory={{ ghapp_broker_runtime_dir }}


### PR DESCRIPTION
`Group=<socket group>` replaces the primary gid, so the broker lost group-read on the ghbroker-group config/policy and crash-looped whenever `ghapp_broker_socket_group != ghapp_broker_group` — exactly the Hermes wiring. Found live by the kubevirt `ghapp-e2e` scenario (igou-io/igou-ansible#280). Unit gains `SupplementaryGroups={{ ghapp_broker_group }}`; the molecule scenario now converges with a distinct socket group and mirrors the unit credentials via `setpriv` in verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV