### PR TITLE
feat(ghapp): confine the broker in a dedicated SELinux domain

### DIFF
--- a/changelogs/fragments/broker-selinux.yml
+++ b/changelogs/fragments/broker-selinux.yml
@@ -1,0 +1,11 @@
+---
+minor_changes:
+  - >-
+    ghapp broker — optional SELinux confinement (``ghapp_broker_selinux_confine``,
+    default true). On SELinux-enabled hosts the role builds and loads a policy
+    module running the broker in a dedicated ``ghbroker_t`` domain with a
+    dedicated socket type, so a confined agent container may connect to the
+    broker socket via a narrowly scoped ``connectto``/``sock_file`` grant
+    instead of disabling the container label or granting connect to a broad
+    host type. Validated enforcing on CentOS Stream 10 via the igou-ansible
+    kubevirt e2e.

--- a/roles/ghapp/defaults/main.yml
+++ b/roles/ghapp/defaults/main.yml
@@ -57,3 +57,11 @@ ghapp_broker_policy:
 ghapp_broker_service_name: ghapp-broker
 # Disable to skip systemd unit start (e.g. molecule containers without systemd).
 ghapp_broker_manage_service: true
+# Confine the broker in its own SELinux domain (ghbroker_t) so a confined agent
+# container may connect to the socket without weakening the container. Only
+# takes effect where SELinux is actually enabled; a no-op otherwise.
+ghapp_broker_selinux_confine: true
+ghapp_broker_selinux_build_packages:
+  - selinux-policy-devel
+  - checkpolicy
+  - policycoreutils

--- a/roles/ghapp/files/ghbroker.te
+++ b/roles/ghapp/files/ghbroker.te
@@ -1,0 +1,44 @@
+policy_module(ghbroker, 1.2.0)
+
+require {
+    type container_t;
+    type var_run_t;
+    type cgroup_t;
+}
+
+########################################
+# Dedicated confined domain for the ghapp token broker daemon.
+type ghbroker_t;
+type ghbroker_exec_t;
+init_daemon_domain(ghbroker_t, ghbroker_exec_t)
+
+########################################
+# The broker's listening socket gets its own type so the cross-domain grant
+# to containers is scoped to exactly this socket, not all of /run.
+type ghbroker_sock_t;
+files_type(ghbroker_sock_t)
+
+type_transition ghbroker_t var_run_t:sock_file ghbroker_sock_t;
+allow ghbroker_t ghbroker_sock_t:sock_file manage_sock_file_perms;
+allow ghbroker_t var_run_t:dir { add_name remove_name write };
+
+########################################
+# Daemon runtime: exec its venv python, mint tokens over HTTPS to GitHub
+# (TLS certs, DNS, tcp/443), read cgroup limits.
+corecmd_exec_bin(ghbroker_t)
+files_exec_usr_files(ghbroker_t)
+# Python mmaps its interpreter (bin_t) and venv shared objects (usr_t).
+allow ghbroker_t bin_t:file map;
+allow ghbroker_t usr_t:file map;
+allow ghbroker_t self:tcp_socket create_stream_socket_perms;
+corenet_tcp_connect_http_port(ghbroker_t)
+sysnet_dns_name_resolve(ghbroker_t)
+miscfiles_read_generic_certs(ghbroker_t)
+allow ghbroker_t cgroup_t:dir search;
+allow ghbroker_t cgroup_t:file read;
+
+########################################
+# The one cross-boundary grant: confined Hermes terminal containers connect
+# to the broker over its socket. Scoped to ghbroker_t / ghbroker_sock_t only.
+allow container_t ghbroker_t:unix_stream_socket connectto;
+allow container_t ghbroker_sock_t:sock_file { getattr write };

--- a/roles/ghapp/meta/argument_specs.yml
+++ b/roles/ghapp/meta/argument_specs.yml
@@ -139,3 +139,16 @@ argument_specs:
         description: >-
           Enable and start the systemd unit. Disable in environments without
           systemd (e.g. molecule containers).
+      ghapp_broker_selinux_confine:
+        type: bool
+        default: true
+        description: >-
+          On SELinux-enabled hosts, build and load a policy module that runs
+          the broker in a dedicated ghbroker_t domain and lets confined
+          containers connect to its socket (scoped connectto). No-op where
+          SELinux is disabled. Also drops NoNewPrivileges from the unit (it
+          blocks the exec-domain transition).
+      ghapp_broker_selinux_build_packages:
+        type: list
+        elements: str
+        description: Packages providing the SELinux refpolicy build toolchain.

--- a/roles/ghapp/tasks/broker.yml
+++ b/roles/ghapp/tasks/broker.yml
@@ -11,6 +11,21 @@
       ghapp_broker_private_key_content, and a non-empty
       ghapp_broker_policy.allowed_repos list.
 
+- name: Gather SELinux facts (gates the confinement block)
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - selinux
+  when: ansible_facts.selinux is not defined
+
+- name: Decide whether the SELinux confinement is active on this host
+  ansible.builtin.set_fact:
+    __ghapp_broker_selinux_active: >-
+      {{
+        (ghapp_broker_selinux_confine | bool)
+        and (ansible_facts.selinux.status | default('disabled') == 'enabled')
+      }}
+
 - name: Create the broker group
   ansible.builtin.group:
     name: "{{ ghapp_broker_group }}"
@@ -82,6 +97,68 @@
     mode: "0640"
   become: true
   notify: Restart the ghapp broker
+
+# On SELinux-enforcing hosts, run the broker in its own confined domain
+# (ghbroker_t) so the single cross-boundary grant — a confined agent container
+# connecting to the broker socket — is scoped to exactly this daemon and its
+# socket, rather than opening the container up (label=disable) or granting
+# connectto to a broad host type. Skipped where SELinux is not enabled
+# (Debian, molecule containers), so those paths are unchanged.
+- name: Configure the broker SELinux domain
+  when: __ghapp_broker_selinux_active | bool
+  become: true
+  block:
+    - name: Install SELinux policy build tooling
+      ansible.builtin.package:
+        name: "{{ ghapp_broker_selinux_build_packages }}"
+        state: present
+
+    - name: Check whether the ghbroker SELinux module is already loaded
+      ansible.builtin.command:
+        cmd: semodule -l
+      register: ghapp_broker_selinux_module_present
+      changed_when: false
+      failed_when: false
+      # noqa command-instead-of-module -- no module lists loaded SELinux policies
+
+    - name: Install the ghbroker SELinux policy source
+      ansible.builtin.copy:
+        src: ghbroker.te
+        dest: "{{ ghapp_broker_config_dir }}/ghbroker.te"
+        owner: root
+        group: root
+        mode: "0644"
+      register: __ghapp_broker_te
+
+    - name: Build and install the ghbroker SELinux module
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          make -f /usr/share/selinux/devel/Makefile ghbroker.pp
+          && semodule -i ghbroker.pp
+        chdir: "{{ ghapp_broker_config_dir }}"
+        executable: /bin/bash
+      register: __ghapp_broker_semodule
+      changed_when: true
+      when: >-
+        __ghapp_broker_te.changed
+        or 'ghbroker' not in ghapp_broker_selinux_module_present.stdout
+      notify: Restart the ghapp broker
+      # noqa command-instead-of-shell -- refpolicy build + module load, no module for it
+
+    - name: Label the ghapp binary as the broker domain entrypoint
+      community.general.sefcontext:
+        target: "{{ ghapp_venv_path }}/bin/ghapp"
+        setype: ghbroker_exec_t
+        state: present
+      notify: Restart the ghapp broker
+
+    - name: Restore the ghapp binary context
+      ansible.builtin.command:
+        cmd: "restorecon -v {{ ghapp_venv_path }}/bin/ghapp"
+      register: __ghapp_broker_restorecon
+      changed_when: __ghapp_broker_restorecon.stdout | length > 0
+      notify: Restart the ghapp broker
 
 - name: Render the broker systemd unit
   ansible.builtin.template:

--- a/roles/ghapp/templates/ghapp-broker.service.j2
+++ b/roles/ghapp/templates/ghapp-broker.service.j2
@@ -25,7 +25,15 @@ Restart=on-failure
 RestartSec=2
 
 # Hardening: the only writable path is the runtime socket directory.
+{% if __ghapp_broker_selinux_active | default(false) | bool %}
+# NoNewPrivileges blocks the SELinux exec-domain transition, so it is dropped
+# when the broker is confined by the ghbroker_t domain — the SELinux type
+# enforcement (stronger, type-scoped) replaces this blanket flag. The rest of
+# the sandbox below still applies.
+NoNewPrivileges=false
+{% else %}
 NoNewPrivileges=true
+{% endif %}
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true


### PR DESCRIPTION
Confined Hermes terminal containers (container_t) can't reach the broker's unix socket under enforcing SELinux. The role now runs the broker in a dedicated `ghbroker_t` domain with a dedicated `ghbroker_sock_t` socket type; the only cross-boundary grant is a scoped `container_t → ghbroker_t connectto` (+ sock_file write) — no container label disable, no broad host-type grant.

Gated on a computed `__ghapp_broker_selinux_active` fact (confine flag AND SELinux enabled), so it's a no-op on Debian / molecule containers. NoNewPrivileges is dropped only when the domain is active (it blocks the exec-transition); the rest of the systemd sandbox stays.

Developed and validated **enforcing on CentOS Stream 10** via the igou-ansible kubevirt e2e: broker in `ghbroker_t`, socket `ghbroker_sock_t`, host + in-container mint both 200, out-of-policy 403 from inside the container, zero AVC denials. Container molecule scenario still green (SELinux path skipped there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV