### PR TITLE
refactor(host_prep): drop gitconfig deletion and GitHub SSH URL rewrite

### DIFF
--- a/changelogs/fragments/38-host-prep-gitconfig.yml
+++ b/changelogs/fragments/38-host-prep-gitconfig.yml
@@ -1,0 +1,7 @@
+---
+breaking_changes:
+  - host_prep role - The ``host_prep_git_github_ssh_rewrite`` variable and the GitHub
+    HTTPS-to-SSH URL rewrite (``url.git@github.com:.insteadOf``) it configured have
+    been removed. The role no longer deletes ``~/.gitconfig`` before configuring git;
+    it now only seeds the file and sets ``user.name`` / ``user.email`` idempotently
+    via ``community.general.git_config`` (https://github.com/david-igou/ansible-collection-devhost/pull/38).

--- a/extensions/molecule/container_runtimes/converge.yml
+++ b/extensions/molecule/container_runtimes/converge.yml
@@ -12,7 +12,6 @@
     packages_install_cursor_agent: true
     packages_install_pip_packages: false
     packages_install_extra_packages: false
-    host_prep_git_github_ssh_rewrite: false
     host_prep_git_user_name: "Test User"
     host_prep_git_user_email: "test@example.com"
     host_prep_ssh_config: |

--- a/extensions/molecule/default/converge.yml
+++ b/extensions/molecule/default/converge.yml
@@ -22,7 +22,6 @@
       # Test bashrc
       export EDITOR=vim
     host_prep_onepassword_service_account_token: "test-token-value"
-    host_prep_git_github_ssh_rewrite: false
     host_prep_devcontainer_repository: "https://github.com/igou-io/igou-devenv.git"
 
     # The repositories to clone into the workspace, cloned to {{ ansible_facts.env.HOME }}/workspace/

--- a/extensions/molecule/host_prep/verify.yml
+++ b/extensions/molecule/host_prep/verify.yml
@@ -65,18 +65,6 @@
           - _git_email.stdout == "test@example.com"
         fail_msg: "git user.email not set correctly"
 
-    - name: Verify GitHub SSH URL rewrite # noqa: command-instead-of-module
-      ansible.builtin.command:
-        cmd: git config --global --get url.git@github.com:.insteadOf
-      register: _git_ssh_rewrite
-      changed_when: false
-
-    - name: Assert GitHub SSH URL rewrite
-      ansible.builtin.assert:
-        that:
-          - _git_ssh_rewrite.stdout == "https://github.com/"
-        fail_msg: "GitHub SSH URL rewrite not configured"
-
     - name: Print verification summary
       ansible.builtin.debug:
         msg:
@@ -85,5 +73,4 @@
           - ".claude.json: {{ _claude_json.stat.exists }}"
           - "git user.name: {{ _git_name.stdout }}"
           - "git user.email: {{ _git_email.stdout }}"
-          - "git ssh rewrite: {{ _git_ssh_rewrite.stdout }}"
           - "Note: ssh_config, bashrc, op token, and git clone tasks are not tested in host_prep scenario"

--- a/roles/host_prep/README.md
+++ b/roles/host_prep/README.md
@@ -9,7 +9,6 @@ Runs **without** `become` — all tasks operate in the user's home directory.
 - Creates bind-mount target directories (`~/.ssh`, `~/.kube`, `~/.config/cursor`, `~/workspace`, etc.)
 - Seeds `~/.gitconfig` and `~/.claude.json` so bind-mounts have existing targets
 - Configures git `user.name` / `user.email` (when set)
-- Rewrites GitHub HTTPS URLs to SSH (`url.git@github.com:.insteadOf`)
 - Creates 1Password config directory and writes service account token (when set)
 - Writes `~/.ssh/config` and `~/.bashrc` from provided content (when set)
 - Clones a devcontainer repository to the home directory
@@ -21,7 +20,6 @@ Runs **without** `become` — all tasks operate in the user's home directory.
 |---|---|---|
 | `host_prep_git_user_name` | `""` | Git global `user.name` (skipped when empty) |
 | `host_prep_git_user_email` | `""` | Git global `user.email` (skipped when empty) |
-| `host_prep_git_github_ssh_rewrite` | `true` | Rewrite GitHub HTTPS to SSH URLs |
 | `host_prep_directories` | *(see defaults)* | List of directories to create |
 | `host_prep_onepassword_service_account_token` | `""` | 1Password service account token (written to `~/.config/op/service-account-token`) |
 | `host_prep_ssh_config` | `""` | Content for `~/.ssh/config` (skipped when empty) |

--- a/roles/host_prep/defaults/main.yml
+++ b/roles/host_prep/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 host_prep_git_user_name: ""
 host_prep_git_user_email: ""
-host_prep_git_github_ssh_rewrite: true
 
 host_prep_directories:
   - "{{ ansible_facts.env.HOME }}/.ssh"

--- a/roles/host_prep/tasks/main.yml
+++ b/roles/host_prep/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Ensure .gitconfig is absent
-  ansible.builtin.file:
-    path: "{{ ansible_facts.env.HOME }}/.gitconfig"
-    state: absent
-  when: host_prep_git_github_ssh_rewrite
-
 - name: Create bind-mount target directories
   ansible.builtin.file:
     path: "{{ item }}"
@@ -82,10 +76,3 @@
     scope: global
     value: "{{ host_prep_git_user_email }}"
   when: host_prep_git_user_email | length > 0
-
-- name: Configure GitHub SSH URL rewrite
-  community.general.git_config:
-    name: "url.git@github.com:.insteadOf"
-    scope: global
-    value: "https://github.com/"
-  when: host_prep_git_github_ssh_rewrite


### PR DESCRIPTION
## Summary

- `host_prep` no longer deletes `~/.gitconfig` before configuring git. It now seeds the file and sets `user.name` / `user.email` idempotently via `community.general.git_config` (matching the `ghapp` role's approach).
- Removes the `host_prep_git_github_ssh_rewrite` variable and the `url.git@github.com:.insteadOf` HTTPS→SSH rewrite it configured.
- Drops the variable from the `default` and `container_runtimes` molecule converge playbooks, and removes the SSH-rewrite assertion from the `host_prep` verify.
- Updates the role README and adds a breaking-change changelog fragment.

## Breaking change

`host_prep_git_github_ssh_rewrite` is removed; the URL rewrite it configured no longer happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * GitHub HTTPS URLs are no longer automatically rewritten to SSH during host preparation.
  * The related configuration option has been removed.

* **Bug Fixes**
  * Git configuration is now preserved and updated idempotently, including Git user name and email settings.

* **Documentation**
  * Updated host preparation documentation and verification checks to reflect the revised Git configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->